### PR TITLE
quick update to the retriever-site installation instructions

### DIFF
--- a/_posts/2016-02-28-install.md
+++ b/_posts/2016-02-28-install.md
@@ -19,15 +19,16 @@ the [Quick Start](#quickstart)). If you have Python installed run:
 pip install retriever
 ```
 
-or if you're Python installation is based on conda or Anaconda use:
+or if your Python installation is based on conda or Anaconda use:
 
 ```
 conda install retriever -c conda-forge
 ```
 
 If you don't have Python installed we recommend
-installing [Anaconda](https://www.continuum.io/downloads) using the default
-options in the installer and then running this conda install command.
+installing it using the [Anaconda](https://www.continuum.io/downloads) installer then running the conda install command above. 
+**NOTE:**
+When installing Anaconda through the installer, make sure that the 'add to PATH' option is checked. 
 
 ### Method 2: Installers
 


### PR DESCRIPTION
updating the retriever-site's anaconda installation instructions due to changes in Anaconda's installation defaults. 